### PR TITLE
fix(extension): use fsPath

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export async function activate(context: ExtensionContext) {
   const storageUri = context.globalStorageUri;
   const sourceUri = Uri.joinPath(extension.extensionUri, 'plugin');
   const platform = os.platform();
-  storagePath = storageUri.toString();
+  storagePath = storageUri.fsPath;
 
   if (platform === 'win32') {
     storagePath = path.join(


### PR DESCRIPTION
This PR aims to fix the standing issue of malformed library paths being used on macOS systems. Linden had previously tried to fix this in https://github.com/CommunityOx/cfxlua-vscode/commit/0c9c689448add30205fd6f0d7571070dd81faef9 but it has remained an issue.

The `toString()` method returns an encoded URI, but because `~/Library/Application Support/Code/User/globalStorage` is the default storage path, the space in "Application Support" is transformed to `%20`, thus causing a malformed path. `fsPath` instead points to the system path.

This has been tested on a Mac and is working (untested on Windows or Linux).