### PR TITLE
Add Open VSX Registry Publishing Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,10 @@ jobs:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
           yarn: true
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          registryUrl: https://open-vsx.org
+          yarn: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 > [!NOTE]
 > **This is a community maintained fork of archived [overextended/cfxlua-vscode](https://github.com/overextended/cfxlua-vscode).**
+> 
+> **Open VSX Support:** This PR adds automated publishing to Open VSX Registry alongside the existing Visual Studio Marketplace publishing, making the extension available to users of open-source VS Code alternatives like VSCodium.
 
 _This extension is not authored, published, sponsored, nor endorsed by Cfx.re._
 


### PR DESCRIPTION
## Overview
This PR adds automated publishing to Open VSX Registry alongside the existing Visual Studio Marketplace publishing, making the CfxLua IntelliSense extension available to users of open-source VS Code alternatives like VSCodium and Cursor IDE.

## Changes Made

### 1. GitHub Workflow Updates
- **File:** `.github/workflows/release.yml`
- **Change:** Added Open VSX Registry publishing step after the existing Visual Studio Marketplace publishing
- **Benefit:** Extension will now be available on both registries automatically

### 2. Documentation Updates
- **File:** `README.md`
- **Change:** Added note about Open VSX support in the PR
- **Benefit:** Users understand the extension is available on both registries

## Technical Details

### Workflow Changes
The workflow now includes two publishing steps:
1. **Visual Studio Marketplace** (existing functionality)
2. **Open VSX Registry** (new functionality)

Both steps use the same `HaaLeo/publish-vscode-extension@v2` action with different registry URLs.

### Required Setup
To enable Open VSX publishing, the following secrets need to be added to the repository:
- `OPEN_VSX_TOKEN`: Access token from open-vsx.org
- The `communityox` namespace needs to be created on Open VSX Registry

### Benefits
- **Broader reach:** Extension available to users of VSCodium and other open-source VS Code alternatives
- **No breaking changes:** Existing Visual Studio Marketplace publishing remains unchanged
- **Automated:** Both registries are updated automatically on every release

## Testing
- [x] Workflow syntax validated
- [x] No breaking changes to existing functionality
- [x] Open VSX publishing step added without affecting VS Marketplace publishing

## Notes
- This change is backward compatible
- Existing users will continue to get updates from Visual Studio Marketplace
- New users can choose between either registry
- The same version number is published to both registries
